### PR TITLE
docs: use go install instead of go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ The package still needs the following:
 
 ### Installation
 
-Use go get.
+Use go install.
 ```bash
-    go get github.com/things-go/go-socks5
+    go install github.com/things-go/go-socks5@latest
 ```
 
 Then import the socks5 server package into your own code.


### PR DESCRIPTION
go get is deprecated for installing binaries, use go install with @latest suffix per Go 1.17+ best practices.

Fixes the installation command in README.md lines 39-41.